### PR TITLE
fix erroneous creation of elements of mapBlockIndex in komodo_checkpoint

### DIFF
--- a/src/komodo_validation013.h
+++ b/src/komodo_validation013.h
@@ -952,7 +952,8 @@ int32_t komodo_checkpoint(int32_t *notarized_heightp,int32_t nHeight,uint256 has
         return(-1);
     notarized_height = komodo_notarizeddata(pindex->nHeight,&notarized_hash,&notarized_desttxid);
     *notarized_heightp = notarized_height;
-    if ( notarized_height >= 0 && notarized_height <= pindex->nHeight && (notary= mapBlockIndex[notarized_hash]) != 0 )
+
+    if ( notarized_height >= 0 && notarized_height <= pindex->nHeight && mapBlockIndex.count(notarized_hash) && (notary= mapBlockIndex[notarized_hash]) != 0 )
     {
         //printf("nHeight.%d -> (%d %s)\n",pindex->nHeight,notarized_height,notarized_hash.ToString().c_str());
         if ( notary->nHeight == notarized_height ) // if notarized_hash not in chain, reorg


### PR DESCRIPTION
`std::map` `[]` syntax when reading from a map does an insert if the item doesn't exist in the map yet.

without this fix RPC call `getblock 0` will lead to a daemon crash, also this error could lead to other unexpected consequences.
